### PR TITLE
Browser Rechtschreibkorrektur in Code-Snippets deaktivieren

### DIFF
--- a/lib/adminer.php
+++ b/lib/adminer.php
@@ -67,6 +67,7 @@ class rex_adminer extends Adminer
                         oncut="return false"
                         onpaste="return false"
                         onkeydown="return event.metaKey"
+                        spellcheck="false"
                     >
                         '.$code.'
                     </div>


### PR DESCRIPTION
Vorher

![image](https://user-images.githubusercontent.com/120441/40446473-a25ed46c-5ecf-11e8-9ba4-851e0bf29a84.png)

Nachher

![image](https://user-images.githubusercontent.com/120441/40446466-9dcdfd42-5ecf-11e8-9336-223334b2f02b.png)

getestet im Firefox.