### PR TITLE
PHP 8: Avoid TypeError

### DIFF
--- a/pages/index.php
+++ b/pages/index.php
@@ -30,6 +30,12 @@ $this->setProperty('database', $database);
 $_GET['username'] = '';
 $_GET['db'] = $database['name'];
 
+// adminer uses `page` parameter for pagination (int), but redaxo initially sets `page=adminer`
+// so we remove the page parameter if it is not a numeric string
+if (isset($_GET['page']) && $_GET['page'] !== (string) (int) $_GET['page']) {
+    unset($_GET['page']);
+}
+
 // workaround against https://github.com/vrana/adminer/commit/15900301eeef0cf22e51f57ed0b7d55b3e822feb
 $_SESSION['pwds']['server'][''][$_GET["username"]] = '';
 


### PR DESCRIPTION
fixes #36, closes #39

https://sourceforge.net/p/adminer/bugs-and-features/778/ wurde geschlossen, da für ihn nicht reproduzierbar.
Daraufhin habe ich es mir nun genauer angeschaut, und es war doch ein Problem auf unserer Seite, aufgrund der Einbindung innerhalb von REDAXO.