### PR TITLE
print host in database chooser

### DIFF
--- a/lib/adminer.php
+++ b/lib/adminer.php
@@ -19,7 +19,7 @@ class rex_adminer extends Adminer
         $databases = [];
 
         foreach (rex_addon::get('adminer')->getProperty('databases') as $db) {
-            $databases[$db['name']] = $db['name'];
+            $databases[$db['name']] = $db['name'].' ('. $db['host'] .')';
         }
 
         return $databases;


### PR DESCRIPTION
when using multiple databases its not always obvious which database is connected on which database host

this PR is adding a hint into the database chooser so we see host (and port)

<img width="293" alt="grafik" src="https://github.com/user-attachments/assets/82b0bfd6-43b0-41f2-9ba2-6a5fe3cc883c">
