### PR TITLE
Addon `adminer` beim Installieren als System-Addon deklarieren

### DIFF
--- a/install.php
+++ b/install.php
@@ -3,7 +3,7 @@
 $addon = rex_addon::get('adminer');
 
 /**
- * Addon in Setup-Addons mit aufnehmen der config.yml in dieser Installation aufnehmen.
+ * Addon in die Setup-Addons in der config.yml dieser Installation hinzufügen.
  */
 $config_file = rex_path::coreData('config.yml');
 $data = rex_file::getConfig($config_file);

--- a/install.php
+++ b/install.php
@@ -1,0 +1,13 @@
+<?php
+
+$addon = rex_addon::get('adminer');
+
+/**
+ * Addon in Setup-Addons mit aufnehmen der config.yml in dieser Installation aufnehmen.
+ */
+$config_file = rex_path::coreData('config.yml');
+$data = rex_file::getConfig($config_file);
+if (array_key_exists('setup_addons', $data) && !in_array('adminer', $data['setup_addons'], true)) {
+    $data['setup_addons'][] = 'adminer';
+    rex_file::putConfig($config_file, $data);
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,13 @@
+<?php
+
+$addon = rex_addon::get('adminer');
+
+/**
+ * Addon aus den Setup-Addons in der config.yml dieser Installation streichen.
+ */
+$config_file = rex_path::coreData('config.yml');
+$data = rex_file::getConfig($config_file);
+if (array_key_exists('setup_addons', $data) && in_array('adminer', $data['setup_addons'], true)) {
+    $data['setup_addons'] = array_diff($data['setup_addons'], ['adminer']);
+    rex_file::putConfig($config_file, $data);
+}


### PR DESCRIPTION
Hilft, auch mal direkt als Entwickler einen Whooops lösen zu können, wenn man in den Safemode wechseln muss.